### PR TITLE
Refactor e2e metrics job

### DIFF
--- a/stages/12-e2e-metrics/e2e-metrics
+++ b/stages/12-e2e-metrics/e2e-metrics
@@ -14,13 +14,13 @@ E2E_METRICS_RUN_ID=$(echo $CI_JOB_ID)
 # create namespace for e2e-metric components
 kubectl create ns $COVERAGE_NAMESPACE
 # clone oep-e2e-aws repo to access files
-git clone https://$username:$password@github.com/mayadata-io/oep-e2e-aws.git
+# git clone https://$username:$password@github.com/mayadata-io/oep-e2e-aws.git
 git clone https://$username:$password@github.com/mayadata-io/oep-e2e.git
-cp oep-e2e/.master-plan.yml oep-e2e-aws/.master-plan.yml
-cd oep-e2e-aws
+cp oep-e2e/.master-plan.yml .master-plan.yml
+# cd oep-e2e-aws
 # create configmap from master test plan file
 kubectl create configmap metrics-config-test -n $COVERAGE_NAMESPACE --from-file=.master-plan.yml --from-file=.gitlab-ci.yml
-cd ..
+# cd ..
 # Cloning e2e-metrics repo 
 git clone https://github.com/mayadata-io/e2e-metrics.git
 # Creating kubernetes resources 


### PR DESCRIPTION
Removed extra git clone statement from e2e  metrics job script so that e2e metrics job can use oep-release branch gitlab.yml file for coverage manipulation .