### PR TITLE
Executing openebs functional stage irrespective of previous stage status

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -607,6 +607,7 @@ OPENEBS-STORAGE-POLICIES:
 .functional_test_template:
   image: mayadataio/tools:gitlab-job-v6
   stage: OPENEBS-FUNCTIONAL
+  when: always
   dependencies:
     - cluster2-setup
 


### PR DESCRIPTION
Signed-off-by: gprasath <giridhara.prasad@mayadata.io>

- Included `when: always` in openebs functional template.
- Irrespective of previous stage's status, this stage will execute always.