### PR TITLE
Passing status of job as completed if previous job gets failed

### DIFF
--- a/stages/10-openebs-install-check/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME
+++ b/stages/10-openebs-install-check/TCID-DIR-OP-DELETE-EXTERNAL-CSPC-WITH-VOLUME
@@ -64,8 +64,11 @@ echo "********** Check Filesystem state **********"
 kubectl logs -f $litmus_pod -n litmus
 testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
 echo $testResult
-if [ "$testResult" != Pass ]; then 
-exit 1; 
+
+if [ "$testResult" != Pass ]
+then
+  bash utils/e2e-cr jobname:tcid-dir-op-delete-external-cspc-with-volume jobphase:Completed
+  exit 1;
 else
-    bash utils/e2e-cr jobname:tcid-dir-op-delete-external-cspc-with-volume jobphase:Completed
+  bash utils/e2e-cr jobname:tcid-dir-op-delete-external-cspc-with-volume jobphase:Completed
 fi

--- a/stages/10-openebs-install-check/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE
+++ b/stages/10-openebs-install-check/TCID-DIR-OP-INSTALL-OPENEBS-CP-ON-SPECIFIC-NODE
@@ -66,9 +66,12 @@ echo "********** Check Filesystem state **********"
 kubectl logs -f $litmus_pod -n litmus
 testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
 echo $testResult
-if [ "$testResult" != Pass ]; then 
-exit 1; 
+
+if [ "$testResult" != Pass ]
+then
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-cp-on-specific-node jobphase:Completed
+  exit 1;
 else
-    bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-cp-on-specific-node jobphase:Completed
-fi
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-cp-on-specific-node jobphase:Completed
+fi 
 

--- a/stages/10-openebs-install-check/TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE
+++ b/stages/10-openebs-install-check/TCID-DIR-OP-INSTALL-OPENEBS-DP-ON-SPECIFIC-NODE
@@ -62,8 +62,11 @@ echo "********** Check Filesystem state **********"
 kubectl logs -f $litmus_pod -n litmus
 testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
 echo $testResult
-if [ "$testResult" != Pass ]; then 
-exit 1; 
+
+if [ "$testResult" != Pass ]
+then
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-dp-on-specific-node jobphase:Completed
+  exit 1;
 else
-    bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-dp-on-specific-node jobphase:Completed
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-dp-on-specific-node jobphase:Completed
 fi 

--- a/stages/10-openebs-install-check/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE
+++ b/stages/10-openebs-install-check/TCID-DIR-OP-INSTALL-OPENEBS-LIMIT-RESOURCE
@@ -58,8 +58,9 @@ testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-column
 echo $testResult
 
 if [ "$testResult" != Pass ]
-then 
-    exit 1;
+then
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-limit-resource jobphase:Completed
+  exit 1;
 else
-    bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-limit-resource jobphase:Completed
+  bash utils/e2e-cr jobname:tcid-dir-op-install-openebs-limit-resource jobphase:Completed
 fi 

--- a/stages/10-openebs-install-check/TCID-DIR-OP-RE-INSTALL-OPENEBS
+++ b/stages/10-openebs-install-check/TCID-DIR-OP-RE-INSTALL-OPENEBS
@@ -64,8 +64,11 @@ echo "********** Check Filesystem state **********"
 kubectl logs -f $litmus_pod -n litmus
 testResult=$(kubectl get litmusresult ${test_name} --no-headers -o custom-columns=:spec.testStatus.result)
 echo $testResult
-if [ "$testResult" != Pass ]; then 
-exit 1; 
+
+if [ "$testResult" != Pass ]
+then
+  bash utils/e2e-cr jobname:tcid-dir-op-re-install-openebs jobphase:Completed
+  exit 1;
 else
-    bash utils/e2e-cr jobname:tcid-dir-op-re-install-openebs jobphase:Completed
+  bash utils/e2e-cr jobname:tcid-dir-op-re-install-openebs jobphase:Completed
 fi 


### PR DESCRIPTION
### What happened?
- When one job is getting failed then after that job other jobs are not getting executed and because of that all the jobs are failing.

### Why we need this PR?
- This PR is helping us to pass the state of jobphase as completed even it the job gets failed.
- Because of this if one job gets failed in pipeline then also other jobs will keep on running .

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>